### PR TITLE
Update ricoh-ls-sdk.d.ts

### DIFF
--- a/src/ricoh-ls-sdk.d.ts
+++ b/src/ricoh-ls-sdk.d.ts
@@ -1,6 +1,6 @@
 /** @module ricoh-ls-sdk
  */
-declare module "@ricoh-live-streaming-api/ricoh-ls-sdk" {
+declare module "@ricoh-live-streaming-api/web-sdk" {
   /** @typedef {String} ConnectionID
    */
   type ConnectionID = string;


### PR DESCRIPTION
```
"@ricoh-live-streaming-api/web-sdk": "1.2.0",
```

package.jsonに上記のような記述を追加してインストールしましたが、
下記のようなエラーが出たため、型定義ファイルを修正しました。

![image](https://user-images.githubusercontent.com/53554808/151098187-5068857d-da29-4020-930b-7a20996a8ef9.png)
